### PR TITLE
Removing auth context store when loading up the app

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -28,6 +28,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     return storedUser ? JSON.parse(storedUser) : null;
   });
 
+  useEffect(() => {
+    localStorage.removeItem("user");
+    setUser(null);
+  }, []);
+
   const [users, setUsers] = useState(() => {
     const storedUsers = localStorage.getItem("users");
     return storedUsers ? JSON.parse(storedUsers) : initialUsers;


### PR DESCRIPTION
When the app is closed - the user is still logged in but the app sends you to the log in page. It's just annoying. 